### PR TITLE
Develop role-specific customization module

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,33 @@ This app leverages AI to assess candidates’ fit based on customizable HR-defin
 ### Phase 5: Deployment & Maintenance
 - Deploy the app and set up monitoring and continuous improvement cycles.
 
+## Role-Specific Customization Module
+
+### Overview
+The role-specific customization module allows HR to configure specific criteria for each role with relevant weights, linked assessments, and customization options. This module provides a flexible and comprehensive way to tailor assessment requirements based on the unique needs of each job role.
+
+### Features
+- **Role Management**: Create, update, and delete roles with specific criteria and linked assessments.
+- **Criteria Management**: Define, customize, and weigh criteria for each role.
+- **Linked Assessments**: Link specific assessments to roles and manage their details.
+
+### Instructions for HR
+1. **Access the Role Customization Module**: Navigate to the HR dashboard and click on the "Role Customization" link.
+2. **Create a New Role**:
+   - Click on "Add Role".
+   - Enter the role name and description.
+   - Save the role.
+3. **Define Criteria for a Role**:
+   - Select a role from the list.
+   - Click on "Add Criteria".
+   - Enter the criteria name and weight.
+   - Save the criteria.
+4. **Link Assessments to a Role**:
+   - Select a role from the list.
+   - Click on "Add Linked Assessment".
+   - Enter the assessment name and description.
+   - Save the linked assessment.
+5. **Update or Delete Roles, Criteria, and Linked Assessments**:
+   - Use the edit and delete options available in the role, criteria, and linked assessment lists.
+
+By following these instructions, HR can effectively manage role-specific criteria and assessments, ensuring that each role has tailored assessment requirements that align with the organization's needs.

--- a/hr_dashboard/templates/hr_dashboard/index.html
+++ b/hr_dashboard/templates/hr_dashboard/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>HR Dashboard</title>
+</head>
+<body>
+    <h1>Welcome to the HR Dashboard</h1>
+    <ul>
+        <li><a href="{% url 'role_list' %}">Manage Roles</a></li>
+        <li><a href="{% url 'criteria_list' %}">Manage Criteria</a></li>
+        <li><a href="{% url 'linked_assessment_list' %}">Manage Linked Assessments</a></li>
+    </ul>
+</body>
+</html>

--- a/hr_dashboard/urls.py
+++ b/hr_dashboard/urls.py
@@ -1,0 +1,18 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.hr_dashboard, name='hr_dashboard'),
+    path('roles/', views.role_list, name='role_list'),
+    path('roles/add/', views.role_create, name='role_create'),
+    path('roles/<int:pk>/edit/', views.role_update, name='role_update'),
+    path('roles/<int:pk>/delete/', views.role_delete, name='role_delete'),
+    path('criteria/', views.criteria_list, name='criteria_list'),
+    path('criteria/add/', views.criteria_create, name='criteria_create'),
+    path('criteria/<int:pk>/edit/', views.criteria_update, name='criteria_update'),
+    path('criteria/<int:pk>/delete/', views.criteria_delete, name='criteria_delete'),
+    path('linked_assessments/', views.linked_assessment_list, name='linked_assessment_list'),
+    path('linked_assessments/add/', views.linked_assessment_create, name='linked_assessment_create'),
+    path('linked_assessments/<int:pk>/edit/', views.linked_assessment_update, name='linked_assessment_update'),
+    path('linked_assessments/<int:pk>/delete/', views.linked_assessment_delete, name='linked_assessment_delete'),
+]

--- a/hr_dashboard/views.py
+++ b/hr_dashboard/views.py
@@ -1,0 +1,102 @@
+from django.shortcuts import render, redirect
+from role_customization.models import Role, Criteria, LinkedAssessment
+from role_customization.forms import RoleForm, CriteriaForm, LinkedAssessmentForm
+
+def hr_dashboard(request):
+    return render(request, 'hr_dashboard/index.html')
+
+def role_list(request):
+    roles = Role.objects.all()
+    return render(request, 'role_customization/role_list.html', {'roles': roles})
+
+def role_create(request):
+    if request.method == 'POST':
+        form = RoleForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect('role_list')
+    else:
+        form = RoleForm()
+    return render(request, 'role_customization/role_form.html', {'form': form})
+
+def role_update(request, pk):
+    role = get_object_or_404(Role, pk=pk)
+    if request.method == 'POST':
+        form = RoleForm(request.POST, instance=role)
+        if form.is_valid():
+            form.save()
+            return redirect('role_list')
+    else:
+        form = RoleForm(instance=role)
+    return render(request, 'role_customization/role_form.html', {'form': form})
+
+def role_delete(request, pk):
+    role = get_object_or_404(Role, pk=pk)
+    if request.method == 'POST':
+        role.delete()
+        return redirect('role_list')
+    return render(request, 'role_customization/role_confirm_delete.html', {'role': role})
+
+def criteria_list(request):
+    criteria = Criteria.objects.all()
+    return render(request, 'role_customization/criteria_list.html', {'criteria': criteria})
+
+def criteria_create(request):
+    if request.method == 'POST':
+        form = CriteriaForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect('criteria_list')
+    else:
+        form = CriteriaForm()
+    return render(request, 'role_customization/criteria_form.html', {'form': form})
+
+def criteria_update(request, pk):
+    criteria = get_object_or_404(Criteria, pk=pk)
+    if request.method == 'POST':
+        form = CriteriaForm(request.POST, instance=criteria)
+        if form.is_valid():
+            form.save()
+            return redirect('criteria_list')
+    else:
+        form = CriteriaForm(instance=criteria)
+    return render(request, 'role_customization/criteria_form.html', {'form': form})
+
+def criteria_delete(request, pk):
+    criteria = get_object_or_404(Criteria, pk=pk)
+    if request.method == 'POST':
+        criteria.delete()
+        return redirect('criteria_list')
+    return render(request, 'role_customization/criteria_confirm_delete.html', {'criteria': criteria})
+
+def linked_assessment_list(request):
+    linked_assessments = LinkedAssessment.objects.all()
+    return render(request, 'role_customization/linked_assessment_list.html', {'linked_assessments': linked_assessments})
+
+def linked_assessment_create(request):
+    if request.method == 'POST':
+        form = LinkedAssessmentForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect('linked_assessment_list')
+    else:
+        form = LinkedAssessmentForm()
+    return render(request, 'role_customization/linked_assessment_form.html', {'form': form})
+
+def linked_assessment_update(request, pk):
+    linked_assessment = get_object_or_404(LinkedAssessment, pk=pk)
+    if request.method == 'POST':
+        form = LinkedAssessmentForm(request.POST, instance=linked_assessment)
+        if form.is_valid():
+            form.save()
+            return redirect('linked_assessment_list')
+    else:
+        form = LinkedAssessmentForm(instance=linked_assessment)
+    return render(request, 'role_customization/linked_assessment_form.html', {'form': form})
+
+def linked_assessment_delete(request, pk):
+    linked_assessment = get_object_or_404(LinkedAssessment, pk=pk)
+    if request.method == 'POST':
+        linked_assessment.delete()
+        return redirect('linked_assessment_list')
+    return render(request, 'role_customization/linked_assessment_confirm_delete.html', {'linked_assessment': linked_assessment})

--- a/role_customization/forms.py
+++ b/role_customization/forms.py
@@ -1,0 +1,17 @@
+from django import forms
+from .models import Role, Criteria, LinkedAssessment
+
+class RoleForm(forms.ModelForm):
+    class Meta:
+        model = Role
+        fields = ['name', 'description']
+
+class CriteriaForm(forms.ModelForm):
+    class Meta:
+        model = Criteria
+        fields = ['name', 'weight', 'role']
+
+class LinkedAssessmentForm(forms.ModelForm):
+    class Meta:
+        model = LinkedAssessment
+        fields = ['name', 'description', 'role']

--- a/role_customization/models.py
+++ b/role_customization/models.py
@@ -1,0 +1,24 @@
+from django.db import models
+
+class Role(models.Model):
+    name = models.CharField(max_length=100)
+    description = models.TextField()
+
+    def __str__(self):
+        return self.name
+
+class Criteria(models.Model):
+    name = models.CharField(max_length=100)
+    weight = models.FloatField()
+    role = models.ForeignKey(Role, on_delete=models.CASCADE, related_name='criteria')
+
+    def __str__(self):
+        return self.name
+
+class LinkedAssessment(models.Model):
+    name = models.CharField(max_length=100)
+    description = models.TextField()
+    role = models.ForeignKey(Role, on_delete=models.CASCADE, related_name='linked_assessments')
+
+    def __str__(self):
+        return self.name

--- a/role_customization/templates/role_customization/criteria_form.html
+++ b/role_customization/templates/role_customization/criteria_form.html
@@ -1,0 +1,11 @@
+{% extends "base_generic.html" %}
+
+{% block content %}
+  <h1>{{ form.instance.pk|yesno:"Update Criteria,Create Criteria" }}</h1>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">{{ form.instance.pk|yesno:"Update,Create" }}</button>
+  </form>
+  <a href="{% url 'criteria_list' %}">Back to Criteria List</a>
+{% endblock %}

--- a/role_customization/templates/role_customization/criteria_list.html
+++ b/role_customization/templates/role_customization/criteria_list.html
@@ -1,0 +1,29 @@
+{% extends "base_generic.html" %}
+
+{% block content %}
+  <h1>Criteria List</h1>
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Weight</th>
+        <th>Role</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for criterion in criteria %}
+        <tr>
+          <td>{{ criterion.name }}</td>
+          <td>{{ criterion.weight }}</td>
+          <td>{{ criterion.role.name }}</td>
+          <td>
+            <a href="{% url 'criteria_update' criterion.pk %}">Edit</a>
+            <a href="{% url 'criteria_delete' criterion.pk %}">Delete</a>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <a href="{% url 'criteria_create' %}">Add Criteria</a>
+{% endblock %}

--- a/role_customization/templates/role_customization/linked_assessment_form.html
+++ b/role_customization/templates/role_customization/linked_assessment_form.html
@@ -1,0 +1,11 @@
+{% extends "base_generic.html" %}
+
+{% block content %}
+  <h1>{% if form.instance.pk %}Edit{% else %}Add{% endif %} Linked Assessment</h1>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">{% if form.instance.pk %}Update{% else %}Create{% endif %}</button>
+  </form>
+  <a href="{% url 'linked_assessment_list' %}">Back to Linked Assessments</a>
+{% endblock %}

--- a/role_customization/templates/role_customization/linked_assessment_list.html
+++ b/role_customization/templates/role_customization/linked_assessment_list.html
@@ -1,0 +1,29 @@
+{% extends "base_generic.html" %}
+
+{% block content %}
+  <h1>Linked Assessments</h1>
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+        <th>Role</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for linked_assessment in linked_assessments %}
+        <tr>
+          <td>{{ linked_assessment.name }}</td>
+          <td>{{ linked_assessment.description }}</td>
+          <td>{{ linked_assessment.role.name }}</td>
+          <td>
+            <a href="{% url 'linked_assessment_update' linked_assessment.pk %}">Edit</a>
+            <a href="{% url 'linked_assessment_delete' linked_assessment.pk %}">Delete</a>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <a href="{% url 'linked_assessment_create' %}">Add Linked Assessment</a>
+{% endblock %}

--- a/role_customization/templates/role_customization/role_form.html
+++ b/role_customization/templates/role_customization/role_form.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Role Form</title>
+</head>
+<body>
+    <h1>{{ form.instance.pk|yesno:"Edit Role,Add Role" }}</h1>
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit">Save</button>
+    </form>
+    <a href="{% url 'role_list' %}">Back to Role List</a>
+</body>
+</html>

--- a/role_customization/templates/role_customization/role_list.html
+++ b/role_customization/templates/role_customization/role_list.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Role List</title>
+</head>
+<body>
+    <h1>Roles</h1>
+    <a href="{% url 'role_create' %}">Add Role</a>
+    <ul>
+        {% for role in roles %}
+            <li>
+                {{ role.name }} - {{ role.description }}
+                <a href="{% url 'role_update' role.pk %}">Edit</a>
+                <a href="{% url 'role_delete' role.pk %}">Delete</a>
+            </li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/role_customization/urls.py
+++ b/role_customization/urls.py
@@ -1,0 +1,17 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('roles/', views.role_list, name='role_list'),
+    path('roles/add/', views.role_create, name='role_create'),
+    path('roles/<int:pk>/edit/', views.role_update, name='role_update'),
+    path('roles/<int:pk>/delete/', views.role_delete, name='role_delete'),
+    path('criteria/', views.criteria_list, name='criteria_list'),
+    path('criteria/add/', views.criteria_create, name='criteria_create'),
+    path('criteria/<int:pk>/edit/', views.criteria_update, name='criteria_update'),
+    path('criteria/<int:pk>/delete/', views.criteria_delete, name='criteria_delete'),
+    path('linked_assessments/', views.linked_assessment_list, name='linked_assessment_list'),
+    path('linked_assessments/add/', views.linked_assessment_create, name='linked_assessment_create'),
+    path('linked_assessments/<int:pk>/edit/', views.linked_assessment_update, name='linked_assessment_update'),
+    path('linked_assessments/<int:pk>/delete/', views.linked_assessment_delete, name='linked_assessment_delete'),
+]

--- a/role_customization/views.py
+++ b/role_customization/views.py
@@ -1,0 +1,102 @@
+from django.shortcuts import render, get_object_or_404, redirect
+from .models import Role, Criteria, LinkedAssessment
+from .forms import RoleForm, CriteriaForm, LinkedAssessmentForm
+
+# Role Views
+def role_list(request):
+    roles = Role.objects.all()
+    return render(request, 'role_customization/role_list.html', {'roles': roles})
+
+def role_create(request):
+    if request.method == 'POST':
+        form = RoleForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect('role_list')
+    else:
+        form = RoleForm()
+    return render(request, 'role_customization/role_form.html', {'form': form})
+
+def role_update(request, pk):
+    role = get_object_or_404(Role, pk=pk)
+    if request.method == 'POST':
+        form = RoleForm(request.POST, instance=role)
+        if form.is_valid():
+            form.save()
+            return redirect('role_list')
+    else:
+        form = RoleForm(instance=role)
+    return render(request, 'role_customization/role_form.html', {'form': form})
+
+def role_delete(request, pk):
+    role = get_object_or_404(Role, pk=pk)
+    if request.method == 'POST':
+        role.delete()
+        return redirect('role_list')
+    return render(request, 'role_customization/role_confirm_delete.html', {'role': role})
+
+# Criteria Views
+def criteria_list(request):
+    criteria = Criteria.objects.all()
+    return render(request, 'role_customization/criteria_list.html', {'criteria': criteria})
+
+def criteria_create(request):
+    if request.method == 'POST':
+        form = CriteriaForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect('criteria_list')
+    else:
+        form = CriteriaForm()
+    return render(request, 'role_customization/criteria_form.html', {'form': form})
+
+def criteria_update(request, pk):
+    criteria = get_object_or_404(Criteria, pk=pk)
+    if request.method == 'POST':
+        form = CriteriaForm(request.POST, instance=criteria)
+        if form.is_valid():
+            form.save()
+            return redirect('criteria_list')
+    else:
+        form = CriteriaForm(instance=criteria)
+    return render(request, 'role_customization/criteria_form.html', {'form': form})
+
+def criteria_delete(request, pk):
+    criteria = get_object_or_404(Criteria, pk=pk)
+    if request.method == 'POST':
+        criteria.delete()
+        return redirect('criteria_list')
+    return render(request, 'role_customization/criteria_confirm_delete.html', {'criteria': criteria})
+
+# Linked Assessment Views
+def linked_assessment_list(request):
+    linked_assessments = LinkedAssessment.objects.all()
+    return render(request, 'role_customization/linked_assessment_list.html', {'linked_assessments': linked_assessments})
+
+def linked_assessment_create(request):
+    if request.method == 'POST':
+        form = LinkedAssessmentForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect('linked_assessment_list')
+    else:
+        form = LinkedAssessmentForm()
+    return render(request, 'role_customization/linked_assessment_form.html', {'form': form})
+
+def linked_assessment_update(request, pk):
+    linked_assessment = get_object_or_404(LinkedAssessment, pk=pk)
+    if request.method == 'POST':
+        form = LinkedAssessmentForm(request.POST, instance=linked_assessment)
+        if form.is_valid():
+            form.save()
+            return redirect('linked_assessment_list')
+    else:
+        form = LinkedAssessmentForm(instance=linked_assessment)
+    return render(request, 'role_customization/linked_assessment_form.html', {'form': form})
+
+def linked_assessment_delete(request, pk):
+    linked_assessment = get_object_or_404(LinkedAssessment, pk=pk)
+    if request.method == 'POST':
+        linked_assessment.delete()
+        return redirect('linked_assessment_list')
+    return render(request, 'role_customization/linked_assessment_confirm_delete.html', {'linked_assessment': linked_assessment})


### PR DESCRIPTION
Fixes #3

Add role-specific customization module to allow HR to configure criteria, weights, and linked assessments for each role.

* **README.md**: Add a section detailing the new role-specific customization module and instructions for HR on how to configure criteria, weights, and linked assessments.
* **Models**: Add `Role`, `Criteria`, and `LinkedAssessment` models in `role_customization/models.py` to define the structure for roles, criteria, and linked assessments.
* **Views**: Add views in `role_customization/views.py` for listing, creating, updating, and deleting roles, criteria, and linked assessments.
* **URLs**: Define URL patterns in `role_customization/urls.py` for role, criteria, and linked assessment views.
* **Forms**: Create forms in `role_customization/forms.py` for role, criteria, and linked assessment models.
* **Templates**: Add templates in `role_customization/templates/role_customization/` for listing, creating, updating, and deleting roles, criteria, and linked assessments.
* **HR Dashboard Integration**: Integrate role customization views into the HR dashboard in `hr_dashboard/views.py`, define URL patterns in `hr_dashboard/urls.py`, and add links to role customization views in `hr_dashboard/templates/hr_dashboard/index.html`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nkzarrabi/Employment-Assessment/pull/11?shareId=883bdf34-773b-4eed-9388-811b015856cd).