### PR TITLE
Integrate React hooks into Django view

### DIFF
--- a/hr_dashboard/urls.py
+++ b/hr_dashboard/urls.py
@@ -15,4 +15,5 @@ urlpatterns = [
     path('linked_assessments/add/', views.linked_assessment_create, name='linked_assessment_create'),
     path('linked_assessments/<int:pk>/edit/', views.linked_assessment_update, name='linked_assessment_update'),
     path('linked_assessments/<int:pk>/delete/', views.linked_assessment_delete, name='linked_assessment_delete'),
+    path('api/criteria/', views.criteria_data, name='criteria_data'),
 ]

--- a/hr_dashboard/views.py
+++ b/hr_dashboard/views.py
@@ -1,6 +1,10 @@
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, get_object_or_404
 from role_customization.models import Role, Criteria, LinkedAssessment
 from role_customization.forms import RoleForm, CriteriaForm, LinkedAssessmentForm
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework import status
+from .serializers import CriteriaSerializer
 
 def hr_dashboard(request):
     return render(request, 'hr_dashboard/index.html')
@@ -100,3 +104,16 @@ def linked_assessment_delete(request, pk):
         linked_assessment.delete()
         return redirect('linked_assessment_list')
     return render(request, 'role_customization/linked_assessment_confirm_delete.html', {'linked_assessment': linked_assessment})
+
+@api_view(['GET', 'POST'])
+def criteria_data(request):
+    if request.method == 'GET':
+        criteria = Criteria.objects.all()
+        serializer = CriteriaSerializer(criteria, many=True)
+        return Response(serializer.data)
+    elif request.method == 'POST':
+        serializer = CriteriaSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+djangorestframework

--- a/src/components/HRInterface.js
+++ b/src/components/HRInterface.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useCriterion } from '../hooks/useCriterion';
 
 const HRInterface = () => {
-  const { criteria, newCriterion, setNewCriterion, addCriterion, removeCriterion } = useCriterion();
+  const { criteria, newCriterion, setNewCriterion, addCriterion, removeCriterion, loading } = useCriterion();
   const [weights, setWeights] = useState({});
 
   const updateWeight = (index, weight) => {
@@ -19,13 +19,18 @@ const HRInterface = () => {
           onChange={(e) => setNewCriterion(e.target.value)}
           placeholder="Enter new criterion"
         />
-        <button onClick={addCriterion}>Add Criterion</button>
+        <button onClick={addCriterion} disabled={loading}>
+          {loading ? 'Adding...' : 'Add Criterion'}
+        </button>
       </div>
+      {loading && <p>Loading...</p>}
       <ul>
         {criteria.map((criterion, index) => (
           <li key={index}>
-            {criterion}
-            <button onClick={() => removeCriterion(index)}>Remove</button>
+            {criterion.name}
+            <button onClick={() => removeCriterion(index)} disabled={loading}>
+              {loading ? 'Removing...' : 'Remove'}
+            </button>
             <input
               type="number"
               value={weights[index] || ''}

--- a/src/hooks/useCriterion.js
+++ b/src/hooks/useCriterion.js
@@ -1,20 +1,55 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import axios from 'axios';
 
 export const useCriterion = (initialCriteria = [], initialNewCriterion = '') => {
   const [criteria, setCriteria] = useState(initialCriteria);
   const [newCriterion, setNewCriterion] = useState(initialNewCriterion);
+  const [loading, setLoading] = useState(false);
 
-  const addCriterion = () => {
+  useEffect(() => {
+    const fetchCriteria = async () => {
+      setLoading(true);
+      try {
+        const response = await axios.get('/api/criteria/');
+        setCriteria(response.data);
+      } catch (error) {
+        console.error('Error fetching criteria:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCriteria();
+  }, []);
+
+  const addCriterion = async () => {
     if (newCriterion.trim() !== '') {
-      setCriteria([...criteria, newCriterion]);
-      setNewCriterion('');
+      setLoading(true);
+      try {
+        const response = await axios.post('/api/criteria/', { name: newCriterion });
+        setCriteria([...criteria, response.data]);
+        setNewCriterion('');
+      } catch (error) {
+        console.error('Error adding criterion:', error);
+      } finally {
+        setLoading(false);
+      }
     }
   };
 
-  const removeCriterion = (index) => {
-    const updatedCriteria = criteria.filter((_, i) => i !== index);
-    setCriteria(updatedCriteria);
+  const removeCriterion = async (index) => {
+    const criterionToRemove = criteria[index];
+    setLoading(true);
+    try {
+      await axios.delete(`/api/criteria/${criterionToRemove.id}/`);
+      const updatedCriteria = criteria.filter((_, i) => i !== index);
+      setCriteria(updatedCriteria);
+    } catch (error) {
+      console.error('Error removing criterion:', error);
+    } finally {
+      setLoading(false);
+    }
   };
 
-  return { criteria, newCriterion, setNewCriterion, addCriterion, removeCriterion };
+  return { criteria, newCriterion, setNewCriterion, addCriterion, removeCriterion, loading };
 };


### PR DESCRIPTION
Fixes #13

Add a new API endpoint for criteria data and update the frontend to interact with it.

* **Backend Changes:**
  - Add a new view function `criteria_data` in `hr_dashboard/views.py` to handle GET and POST requests for criteria data using Django REST framework.
  - Import necessary modules from Django REST framework in `hr_dashboard/views.py`.
  - Update `hr_dashboard/urls.py` to include a new path for the criteria data API endpoint.

* **Frontend Changes:**
  - Update `useCriterion` hook in `src/hooks/useCriterion.js` to fetch criteria data from the Django API using `useEffect`.
  - Add a new state variable `loading` in `src/hooks/useCriterion.js` to manage loading state.
  - Update `addCriterion` and `removeCriterion` functions in `src/hooks/useCriterion.js` to make API calls to the Django API.
  - Update `HRInterface` component in `src/components/HRInterface.js` to display loading state.
  - Update `addCriterion` and `removeCriterion` functions in `src/components/HRInterface.js` to handle API responses.

* **Dependencies:**
  - Add `djangorestframework` to `requirements.txt`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nkzarrabi/Employment-Assessment/pull/14?shareId=259d3a85-3520-475d-b9aa-c1ac69d6a359).