### PR TITLE
Add autopep8 to all python files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Run autopep8
       run: |
-        find . -name "*.py" | xargs autopep8 --in-place --aggressive --aggressive
+        autopep8 --in-place --aggressive --aggressive .
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Run autopep8
       run: |
-        autopep8 --in-place --aggressive --aggressive .
+        find . -name "*.py" | xargs autopep8 --in-place --aggressive --aggressive
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,14 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
+    - name: Install autopep8
+      run: |
+        pip install autopep8
+
+    - name: Run autopep8
+      run: |
+        autopep8 --in-place --aggressive --aggressive .
+
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 djangorestframework
+autopep8


### PR DESCRIPTION
Fixes #19

Add autopep8 to all Python files and update GitHub Actions workflow.

* **requirements.txt**
  - Add `autopep8` to the list of dependencies.

* **.github/workflows/main.yml**
  - Add a step to install `autopep8` after installing dependencies.
  - Add a step to run `autopep8` on all Python files after installing `autopep8`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nkzarrabi/Employment-Assessment/pull/20?shareId=8b17ac91-ac3a-420a-b2a5-41c4ee15cbff).