### PR TITLE
Deployment to Github Pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,29 +30,24 @@ jobs:
         cd react_app
         npm install
 
-    - name: Install react-scripts
-      run: |
-        cd react_app
-        npm install react-scripts
-
     - name: Build React app
       run: |
         cd react_app
         npm run build
+
+    - name: Verify Build Directory
+      run: |
+        ls -la react_app/build || echo "Build directory not found"
 
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: '3.8'
 
-    - name: Install dependencies
+    - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-
-    - name: Install autopep8
-      run: |
-        pip install autopep8
 
     - name: Collect static files
       env:
@@ -60,16 +55,13 @@ jobs:
       run: |
         python manage.py collectstatic --noinput
 
-    - name: Run autopep8
+    - name: Run Python formatting and linting
       run: |
+        pip install autopep8 flake8
         find . -name "*.py" | xargs autopep8 --in-place --aggressive --aggressive
-
-    - name: Lint with flake8
-      run: |
-        pip install flake8
         flake8 .
 
-    - name: Run tests
+    - name: Run Django tests
       env:
         DJANGO_SETTINGS_MODULE: EmploymentAssessment.settings
       run: |
@@ -78,18 +70,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-  
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-  
+
     - name: Deploy to GitHub Pages
-      run: |
-        cd react_app/build
-        git init
-        git checkout --orphan gh-pages
-        git add .
-        git -c user.name='github-actions[bot]' -c user.email='github-actions[bot]@users.noreply.github.com' commit -m "Deploy to GitHub Pages"
-        git push --force --quiet "https://${{ secrets.GITHUB_TOKEN }}@github.com/nkzarrabi/Employment-Assessment.git" gh-pages:gh-pages
-
-
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: react_app/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,8 +84,12 @@ jobs:
       uses: actions/checkout@v2
   
     - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: react_app/build
+      run: |
+        cd react_app/build
+        git init
+        git checkout --orphan gh-pages
+        git add .
+        git -c user.name='github-actions[bot]' -c user.email='github-actions[bot]@users.noreply.github.com' commit -m "Deploy to GitHub Pages"
+        git push --force --quiet "https://${{ secrets.GITHUB_TOKEN }}@github.com/nkzarrabi/Employment-Assessment.git" gh-pages:gh-pages
+
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,14 +78,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main'
-
+  
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-
+  
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: react_app/build
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,19 @@ jobs:
       with:
         node-version: '14'
 
+    - name: Clear cache
+      run: |
+        rm -rf ~/.npm
+
     - name: Install Node.js dependencies
       run: |
         cd react_app
         npm install
+
+    - name: Install react-scripts
+      run: |
+        cd react_app
+        npm install react-scripts
 
     - name: Build React app
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,20 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Deploy to production
+    - name: Configure Git user
       run: |
-        echo "Deploying to production..."
-        # Add your deployment script here
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+    - name: Build React app
+      run: |
+        cd react_app
+        npm run build
+
+    - name: Deploy to Github Pages
+      run: |
+        cd react_app
+        git init
+        git add build
+        git commit -m 'Deploy to Github Pages'
+        git push --force --quiet "https://${{ secrets.GITHUB_TOKEN }}@github.com/nkzarrabi/Employment-Assessment.git" master:gh-pages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,25 +78,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/main'
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Configure Git user
-      run: |
-        git config --global user.name 'github-actions[bot]'
-        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-
-    - name: Build React app
-      run: |
-        cd react_app
-        npm run build
-
-    - name: Deploy to Github Pages
-      run: |
-        cd react_app
-        git init
-        git add build
-        git commit -m 'Deploy to Github Pages'
-        git push --force --quiet "https://${{ secrets.GITHUB_TOKEN }}@github.com/nkzarrabi/Employment-Assessment.git" master:gh-pages
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: react_app/build

--- a/README.md
+++ b/README.md
@@ -64,3 +64,44 @@ The role-specific customization module allows HR to configure specific criteria 
    - Use the edit and delete options available in the role, criteria, and linked assessment lists.
 
 By following these instructions, HR can effectively manage role-specific criteria and assessments, ensuring that each role has tailored assessment requirements that align with the organization's needs.
+
+## Deployment to Github Pages
+
+### Prerequisites
+- Ensure you have a Github repository for your project.
+- Ensure you have Github Pages enabled for your repository.
+
+### Steps
+1. **Add `homepage` to `package.json`**:
+   - Open `react_app/package.json`.
+   - Add the following line: `"homepage": "https://<your-github-username>.github.io/<your-repo-name>"`.
+
+2. **Update Github Actions Workflow**:
+   - Open `.github/workflows/main.yml`.
+   - Add the following steps to the `deploy` job:
+     ```yaml
+     - name: Configure Git user
+       run: |
+         git config --global user.name 'github-actions[bot]'
+         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+     - name: Build React app
+       run: |
+         cd react_app
+         npm run build
+
+     - name: Deploy to Github Pages
+       run: |
+         cd react_app
+         git init
+         git add build
+         git commit -m 'Deploy to Github Pages'
+         git push --force --quiet "https://${{ secrets.GITHUB_TOKEN }}@github.com/<your-github-username>/<your-repo-name>.git" master:gh-pages
+     ```
+
+3. **Commit and Push Changes**:
+   - Commit and push the changes to your repository.
+   - Github Actions will automatically build and deploy your React app to Github Pages.
+
+4. **Access Your Deployed App**:
+   - Open your browser and navigate to `https://<your-github-username>.github.io/<your-repo-name>` to see your deployed React app.

--- a/react_app/package.json
+++ b/react_app/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Employment Assessment React App",
   "main": "src/index.js",
+  "homepage": "https://nkzarrabi.github.io/Employment-Assessment",
   "scripts": {
     "start": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts build",


### PR DESCRIPTION
Fixes #41

Add deployment to Github Pages.

* **`react_app/package.json`**:
  - Add a `homepage` field with the URL of the Github Pages site.

* **`.github/workflows/main.yml`**:
  - Add a step to configure Git user in the `deploy` job.
  - Add a step to build the React app in the `deploy` job.
  - Add a step to deploy the `react_app/build` directory to the `gh-pages` branch in the `deploy` job.

* **`README.md`**:
  - Add instructions for deploying the project to Github Pages.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nkzarrabi/Employment-Assessment/pull/42?shareId=3fb544d8-5579-4c10-93cc-b4a989851bf3).